### PR TITLE
fix: remove spaces from card data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tonder.io/ionic-lite-sdk",
-  "version": "0.0.52",
+  "version": "0.0.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tonder.io/ionic-lite-sdk",
-      "version": "0.0.52",
+      "version": "0.0.54",
       "license": "ISC",
       "dependencies": {
         "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonder.io/ionic-lite-sdk",
-  "version": "0.0.52",
+  "version": "0.0.54",
   "description": "Tonder ionic lite SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/classes/liteCheckout.ts
+++ b/src/classes/liteCheckout.ts
@@ -90,7 +90,13 @@ export class LiteCheckout extends BaseInlineCheckout implements ILiteCheckout{
       const skyflowTokens: ISaveCardSkyflowRequest = await getSkyflowTokens({
         vault_id: vault_id,
         vault_url: vault_url,
-        data: card,
+        data: {...card, 
+          card_number: card.card_number.replace(/\s+/g, ""),
+          expiration_month: card.expiration_month.replace(/\s+/g, ""),
+          expiration_year: card.expiration_year.replace(/\s+/g, ""),
+          cvv: card.cvv.replace(/\s+/g, ""),
+          cardholder_name: card.cardholder_name.replace(/\s+/g, ""),
+        },
         baseUrl: this.baseUrl,
         apiKey: this.apiKeyTonder,
       });


### PR DESCRIPTION
Updates the getSkyflowTokens call to strip spaces from card numbers before submission.
This prevents validation errors when users enter card numbers with spaces.

Bumps package version from 0.0.52 to 0.0.54.
