### PR TITLE
feat: replace raw card inputs with Skyflow Elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ interface IEventSecureInput {
 }
 ```
 
-> **PCI note:** `value` is only populated in `development` mode. In `production`, `value` is always `''` for sensitive fields (`card_number`, `cvv`); non-sensitive fields (`cardholder_name`, `expiration_month`, `expiration_year`) may still return their value. Use `isValid` and `isEmpty` for UI state logic — never depend on `value` in production.
+> **PCI note:** In `production`, all fields return `value: ''` except `card_number`, which returns a masked value (first digits only). In `stage`, `development`, and `sandbox`, `value` is fully populated for all fields. Use `isValid` and `isEmpty` for UI state logic — never depend on `value` in production.
 
 **Example — live card form validation:**
 
@@ -1148,26 +1148,7 @@ new LiteCheckout({
 
 ### 11.2 Per-field styles
 
-Override styles for individual fields using the field keys in `IStyles`. These take priority over `cardForm` styles.
-
-> **Key difference from `cardForm`:** Per-field keys are directly `CollectInputStylesVariant` — variants like `base`, `focus`, `invalid` go at the top level. There is **no** `inputStyles` wrapper.
-
-**Available style variants for `CollectInputStylesVariant`:**
-
-```typescript
-interface CollectInputStylesVariant {
-  base?: Record<string, any>;           // Default state
-  focus?: Record<string, any>;          // When field has focus
-  complete?: Record<string, any>;       // When field has a valid value
-  invalid?: Record<string, any>;        // When value fails validation
-  empty?: Record<string, any>;          // When field is empty (unfocused)
-  cardIcon?: Record<string, any>;       // Card brand icon (card_number only)
-  dropdownIcon?: Record<string, any>;   // Dropdown arrow icon
-  dropdown?: Record<string, any>;       // Dropdown container
-  dropdownListItem?: Record<string, any>; // Each dropdown option
-  global?: Record<string, any>;         // Applied to the iframe root element
-}
-```
+Override styles for individual fields using the field keys in `IStyles`. These take priority over `cardForm` styles and use the **same structure as `cardForm`** (`inputStyles`, `labelStyles`, `errorStyles`), so you can override the label and error text per field as well.
 
 **Per-field keys in `IStyles`:**
 
@@ -1179,35 +1160,49 @@ interface CollectInputStylesVariant {
 | `expirationMonth` | Expiration month field |
 | `expirationYear` | Expiration year field |
 
-**Example — highlight CVV with a different color scheme:**
+**Example — highlight CVV with a different color scheme and custom label:**
 
 ```typescript
 customization: {
   styles: {
     cvv: {
-      base: { borderColor: '#8e44ad', backgroundColor: '#faf5ff' },
-      focus: { borderColor: '#6c3483', boxShadow: '0 0 0 3px rgba(108,52,131,0.2)' },
-      invalid: { borderColor: '#e74c3c', color: '#e74c3c' },
-      complete: { borderColor: '#27ae60' },
+      inputStyles: {
+        base:     { borderColor: '#8e44ad', backgroundColor: '#faf5ff' },
+        focus:    { borderColor: '#6c3483', boxShadow: '0 0 0 3px rgba(108,52,131,0.2)' },
+        invalid:  { borderColor: '#e74c3c', color: '#e74c3c' },
+        complete: { borderColor: '#27ae60' },
+      },
+      labelStyles: {
+        base: { color: '#8e44ad', fontWeight: '600' },
+      },
+      errorStyles: {
+        base: { color: '#e74c3c', fontSize: '11px' },
+      },
     },
   },
 }
 ```
 
-**Example — full per-field override:**
+**Example — card number with custom input and icon styles:**
 
 ```typescript
 customization: {
   styles: {
     cardNumber: {
-      base: { letterSpacing: '2px', fontFamily: '"Courier New", monospace' },
-      cardIcon: { width: '32px', height: '20px' },
+      inputStyles: {
+        base:    { letterSpacing: '2px', fontFamily: '"Courier New", monospace' },
+        cardIcon: { width: '32px', height: '20px' },
+      },
     },
     expirationMonth: {
-      base: { textAlign: 'center' },
+      inputStyles: {
+        base: { textAlign: 'center' },
+      },
     },
     expirationYear: {
-      base: { textAlign: 'center' },
+      inputStyles: {
+        base: { textAlign: 'center' },
+      },
     },
   },
 }

--- a/src/helpers/skyflow.ts
+++ b/src/helpers/skyflow.ts
@@ -188,9 +188,9 @@ export async function mountSkyflowFields(event: {
   };
 
   const getFieldStyles = (field: CardFieldEnum) => {
-    const perFieldInputStyles = customization?.styles?.[fieldToStyleKey[field]];
+    const perField = customization?.styles?.[fieldToStyleKey[field]];
     const form = customization?.styles?.cardForm;
-    const resolvedInputStyles = perFieldInputStyles ?? form?.inputStyles ?? DEFAULT_SKYFLOW_INPUT_STYLES;
+    const resolvedInputStyles = perField?.inputStyles ?? form?.inputStyles ?? DEFAULT_SKYFLOW_INPUT_STYLES;
 
     // For card_number: inject paddingLeft default so text doesn't overlap the card-network icon.
     // Applied only when the icon is visible (enableCardIcon !== false) and the developer
@@ -208,8 +208,8 @@ export async function mountSkyflowFields(event: {
 
     return {
       inputStyles,
-      labelStyles: form?.labelStyles ?? DEFAULT_SKYFLOW_lABEL_STYLES,
-      errorStyles: form?.errorStyles ?? DEFAULT_SKYFLOW_ERROR_TEXT_STYLES,
+      labelStyles: perField?.labelStyles ?? form?.labelStyles ?? DEFAULT_SKYFLOW_lABEL_STYLES,
+      errorStyles: perField?.errorStyles ?? form?.errorStyles ?? DEFAULT_SKYFLOW_ERROR_TEXT_STYLES,
     };
   };
 

--- a/src/types/commons.ts
+++ b/src/types/commons.ts
@@ -217,16 +217,16 @@ export interface IFormPlaceholder {
 
 export interface IStyles {
   cardForm?: ILiteCardFormStyles;
-  /** Input-element styles applied only to the cardholder name field. Overrides `cardForm.inputStyles` for this field. */
-  cardholderName?: CollectInputStylesVariant;
-  /** Input-element styles applied only to the card number field. Overrides `cardForm.inputStyles` for this field. */
-  cardNumber?: CollectInputStylesVariant;
-  /** Input-element styles applied only to the CVV field. Overrides `cardForm.inputStyles` for this field. */
-  cvv?: CollectInputStylesVariant;
-  /** Input-element styles applied only to the expiration month field. Overrides `cardForm.inputStyles` for this field. */
-  expirationMonth?: CollectInputStylesVariant;
-  /** Input-element styles applied only to the expiration year field. Overrides `cardForm.inputStyles` for this field. */
-  expirationYear?: CollectInputStylesVariant;
+  /** Styles applied only to the cardholder name field. Overrides `cardForm` styles for this field. Same structure as `cardForm` — use `inputStyles`, `labelStyles`, and `errorStyles`. */
+  cardholderName?: ILiteCardFormStyles;
+  /** Styles applied only to the card number field. Overrides `cardForm` styles for this field. Same structure as `cardForm` — use `inputStyles`, `labelStyles`, and `errorStyles`. */
+  cardNumber?: ILiteCardFormStyles;
+  /** Styles applied only to the CVV field. Overrides `cardForm` styles for this field. Same structure as `cardForm` — use `inputStyles`, `labelStyles`, and `errorStyles`. */
+  cvv?: ILiteCardFormStyles;
+  /** Styles applied only to the expiration month field. Overrides `cardForm` styles for this field. Same structure as `cardForm` — use `inputStyles`, `labelStyles`, and `errorStyles`. */
+  expirationMonth?: ILiteCardFormStyles;
+  /** Styles applied only to the expiration year field. Overrides `cardForm` styles for this field. Same structure as `cardForm` — use `inputStyles`, `labelStyles`, and `errorStyles`. */
+  expirationYear?: ILiteCardFormStyles;
   /**
    * Show the card-network icon inside the card number Skyflow Element.
    * Corresponds to Skyflow's `CollectElementOptions.enableCardIcon`.


### PR DESCRIPTION
Breaking changes:
- saveCustomerCard() no longer accepts a card object argument; card data
  must be collected via mountCardFields() before calling it
- payment() no longer accepts raw card fields; card param is now string
  (skyflow_id) only — new-card data comes from mounted Skyflow Elements

New features:
- mountCardFields() mounts Skyflow secure iframes for card data collection;
  supports new-card form (5 fields) and saved-card CVV (with card_id)
- unmountCardFields() with context support ('all', 'create', 'current',
  'update:<skyflow_id>') for fine-grained lifecycle management
- revealCardFields() renders collected card tokens via Skyflow Reveal
  Elements after a successful saveCustomerCard() or new-card payment()
- IEventSecureInput.value forwarded from Skyflow element events;
  suppressed for sensitive fields in Skyflow.Env.PROD

Fixes:
- Skyflow environment now correctly maps mode='production' → Skyflow.Env.PROD,
  all other modes → Skyflow.Env.DEV

Types:
- IMountCardFieldsRequest, CardField, IRevealCardFieldsRequest,
  IRevealCardField, IRevealElementStyles, RevealableCardField added
  and exported from index.ts
- IEventSecureInput.value added to commons.ts
- IStyles extended with per-field keys (cardholderName, cardNumber,
  cvv, expirationMonth, expirationYear) as CollectInputStylesVariant
