### PR TITLE
feat: replace raw card inputs with Skyflow Elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tonder.io/ionic-lite-sdk",
-  "version": "0.0.69",
+  "version": "0.0.69-beta.TEC-192.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tonder.io/ionic-lite-sdk",
-      "version": "0.0.69",
+      "version": "0.0.69-beta.TEC-192.4",
       "license": "ISC",
       "dependencies": {
         "lodash.get": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonder.io/ionic-lite-sdk",
-  "version": "0.0.69",
+  "version": "0.0.69-beta.TEC-192.4",
   "description": "Tonder ionic lite SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/helpers/skyflow.ts
+++ b/src/helpers/skyflow.ts
@@ -305,6 +305,18 @@ export async function mountSkyflowFields(event: {
           },
           key === CardFieldEnum.CARD_NUMBER ? cardIconOption : undefined,
         );
+        handleSkyflowElementEvents({
+          element,
+          errorStyles: getFieldStyles(key).errorStyles,
+          fieldMessage: [
+            CardFieldEnum.CVV,
+            CardFieldEnum.EXPIRATION_MONTH,
+            CardFieldEnum.EXPIRATION_YEAR,
+          ].includes(key)
+            ? ""
+            : labels[key],
+          events: eventsByField[key],
+        });
         const containerId =
           fieldObj.container_id ||
           `#collect_${String(key)}` + (data.card_id ? `_${data.card_id}` : "");


### PR DESCRIPTION
Breaking changes:
- saveCustomerCard() no longer accepts a card object argument; card data
  must be collected via mountCardFields() before calling it
- payment() no longer accepts raw card fields; card param is now string
  (skyflow_id) only — new-card data comes from mounted Skyflow Elements

New features:
- mountCardFields() mounts Skyflow secure iframes for card data collection;
  supports new-card form (5 fields) and saved-card CVV (with card_id)
- unmountCardFields() with context support ('all', 'create', 'current',
  'update:<skyflow_id>') for fine-grained lifecycle management
- revealCardFields() renders collected card tokens via Skyflow Reveal
  Elements after a successful saveCustomerCard() or new-card payment()
- IEventSecureInput.value forwarded from Skyflow element events;
  suppressed for sensitive fields in Skyflow.Env.PROD

Fixes:
- Skyflow environment now correctly maps mode='production' → Skyflow.Env.PROD,
  all other modes → Skyflow.Env.DEV

Types:
- IMountCardFieldsRequest, CardField, IRevealCardFieldsRequest,
  IRevealCardField, IRevealElementStyles, RevealableCardField added
  and exported from index.ts
- IEventSecureInput.value added to commons.ts
- IStyles extended with per-field keys (cardholderName, cardNumber,
  cvv, expirationMonth, expirationYear) as CollectInputStylesVariant
